### PR TITLE
libavformat/hls: use local var url for log to avoid crash

### DIFF
--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -1979,17 +1979,18 @@ static int hls_read_header(AVFormatContext *s)
         pls->ctx->interrupt_callback = s->interrupt_callback;
         url = av_strdup(pls->segments[0]->url);
         ret = av_probe_input_buffer(&pls->pb, &in_fmt, url, NULL, 0, 0);
-        av_free(url);
         if (ret < 0) {
             /* Free the ctx - it isn't initialized properly at this point,
              * so avformat_close_input shouldn't be called. If
              * avformat_open_input fails below, it frees and zeros the
              * context, so it doesn't need any special treatment like this. */
-            av_log(s, AV_LOG_ERROR, "Error when loading first segment '%s'\n", pls->segments[0]->url);
+            av_log(s, AV_LOG_ERROR, "Error when loading first segment '%s'\n", url);
             avformat_free_context(pls->ctx);
             pls->ctx = NULL;
+            av_free(url);
             goto fail;
         }
+        av_free(url);
         pls->ctx->pb       = &pls->pb;
         pls->ctx->io_open  = nested_io_open;
         pls->ctx->flags   |= s->flags & ~AVFMT_FLAG_CUSTOM_IO;


### PR DESCRIPTION
During operation, the user exits and interrupts,
causing pls->segment to be released,
resulting in a null pointer crash

Signed-off-by: bevis <javashu2012@gmail.com>
Signed-off-by: Steven Liu <lq@chinaffmpeg.org>